### PR TITLE
Updated song-catalog.csv and ran update-songs to match RC-500 memory

### DIFF
--- a/cho/ABC/A/Ace/HowLong-a.cho
+++ b/cho/ABC/A/Ace/HowLong-a.cho
@@ -1,14 +1,15 @@
 {title: How Long}
 {artist: Ace}
-{duration: 3:00}
 {key: A}
+{duration: 3:00}
 {tempo: 121}
 {meta: countin: 4}
+{meta: backing: 48}
 
-{comment: ***********************************************}
-{comment: **  meta: countin: 4}
-{comment: ***********************************************}
-
+{comment:***********************************************}
+{comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 48   }
+{comment:***********************************************}
 
 {comment: Intro - Bass Only}
 . | [G/A] . . . | [A] . . . | [G/A] . . . | [A] . . . |

--- a/cho/ABC/A/Ace/HowLong.cho
+++ b/cho/ABC/A/Ace/HowLong.cho
@@ -1,14 +1,15 @@
 {title: How Long}
 {artist: Ace}
-{duration: 3:00}
 {key: Bb}
+{duration: 3:00}
 {tempo: 121}
 {meta: countin: 4}
+{meta: backing: 48}
 
-{comment: ***********************************************}
-{comment: **  meta: countin: 4}
-{comment: ***********************************************}
-
+{comment:***********************************************}
+{comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 48   }
+{comment:***********************************************}
 
 {comment: Intro - Bass Only}
 . | [Ab/Bb] . . . | [Bb] . . . | [Ab/Bb] . . . | [Bb] . . . |

--- a/cho/ABC/A/AlbertHammond/ItNeverRains.cho
+++ b/cho/ABC/A/AlbertHammond/ItNeverRains.cho
@@ -5,10 +5,12 @@
 {tempo: 117}
 {meta: nord: O23}
 {meta: countin: 4}
+{meta: backing: 71}
 
 {comment:***********************************************}
 {comment:**  meta: nord: O23   }
 {comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 71   }
 {comment:***********************************************}
 
 {comment: Intro - 8 bars}

--- a/cho/ABC/A/AvrilLavigne/Complicated-c#m.cho
+++ b/cho/ABC/A/AvrilLavigne/Complicated-c#m.cho
@@ -4,10 +4,12 @@
 {duration: 3:40}
 {tempo: 78}
 {meta: countin: 4}
+{meta: backing: 94}
 {meta: performance: C#m}
 
 {comment:***********************************************}
 {comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 94   }
 {comment:**  meta: performance: C#m   }
 {comment:***********************************************}
 

--- a/cho/ABC/A/AvrilLavigne/Complicated-em.cho
+++ b/cho/ABC/A/AvrilLavigne/Complicated-em.cho
@@ -3,9 +3,13 @@
 {key: Em}
 {duration: 3:40}
 {tempo: 78}
+{meta: countin: 4}
+{meta: backing: 94}
 
-{comment: ***********************************************}
-{comment: ***********************************************}
+{comment:***********************************************}
+{comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 94   }
+{comment:***********************************************}
 
 {comment: Duration: 3:25}
 

--- a/cho/ABC/A/AvrilLavigne/Complicated.cho
+++ b/cho/ABC/A/AvrilLavigne/Complicated.cho
@@ -3,9 +3,13 @@
 {key: Dm}
 {duration: 3:40}
 {tempo: 78}
+{meta: countin: 4}
+{meta: backing: 94}
 
-{comment: ***********************************************}
-{comment: ***********************************************}
+{comment:***********************************************}
+{comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 94   }
+{comment:***********************************************}
 
 {comment: Duration: 3:25}
 

--- a/cho/ABC/B/BachmanTurnerOverdrive/TakinCareOfBusiness.cho
+++ b/cho/ABC/B/BachmanTurnerOverdrive/TakinCareOfBusiness.cho
@@ -4,10 +4,14 @@
 {duration: 4:50}
 {tempo: 130}
 {meta: nord: N41}
+{meta: countin: 8}
+{meta: backing: 25}
 
-{comment: ***********************************************}
-{comment: **  meta: nord: N41}
-{comment: ***********************************************}
+{comment:***********************************************}
+{comment:**  meta: nord: N41   }
+{comment:**  meta: countin: 8   }
+{comment:**  meta: backing: 25   }
+{comment:***********************************************}
 
 {columns: 2}
 

--- a/cho/ABC/C/CuttingCrew/DiedInYourArms.cho
+++ b/cho/ABC/C/CuttingCrew/DiedInYourArms.cho
@@ -4,9 +4,11 @@
 {duration: 4:05}
 {tempo: 125}
 {meta: countin: 8}
+{meta: backing: 45}
 
 {comment:***********************************************}
 {comment:**  meta: countin: 8   }
+{comment:**  meta: backing: 45   }
 {comment:***********************************************}
 
 {comment: Intro ( keyboards )}

--- a/cho/DEF/D/DoobieBros/LongTrainRunning.cho
+++ b/cho/DEF/D/DoobieBros/LongTrainRunning.cho
@@ -3,9 +3,13 @@
 {key: Gm}
 {duration: 3:20}
 {tempo: 117}
+{meta: countin: 4}
+{meta: backing: 82}
 
-{comment: ***********************************************}
-{comment: ***********************************************}
+{comment:***********************************************}
+{comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 82   }
+{comment:***********************************************}
 
 {comment: Intro}
 

--- a/cho/GHI/H/HalKetchum/SmallTownSaturdayNight.cho
+++ b/cho/GHI/H/HalKetchum/SmallTownSaturdayNight.cho
@@ -4,10 +4,12 @@
 {duration: 2:30}
 {tempo: 100}
 {meta: countin: 8}
+{meta: backing: 49}
 {meta: performance: G}
 
 {comment:***********************************************}
 {comment:**  meta: countin: 8   }
+{comment:**  meta: backing: 49   }
 {comment:**  meta: performance: G   }
 {comment:***********************************************}
 

--- a/cho/JKL/J/JimCroce/BadBadLeroyBrown.cho
+++ b/cho/JKL/J/JimCroce/BadBadLeroyBrown.cho
@@ -5,10 +5,12 @@
 {tempo: 148}
 {meta: nord: O55}
 {meta: countin: 8}
+{meta: backing: 85}
 
 {comment:***********************************************}
 {comment:**  meta: nord: O55   }
 {comment:**  meta: countin: 8   }
+{comment:**  meta: backing: 85   }
 {comment:***********************************************}
 
 {comment:Intro}

--- a/cho/JKL/J/JoDeeMessina/ByeBye-bb.cho
+++ b/cho/JKL/J/JoDeeMessina/ByeBye-bb.cho
@@ -5,11 +5,13 @@
 {tempo: 134}
 {meta: nord: O24}
 {meta: countin: 8}
+{meta: backing: 89}
 {meta: performance: Bb}
 
 {comment:***********************************************}
 {comment:**  meta: nord: O24   }
 {comment:**  meta: countin: 8   }
+{comment:**  meta: backing: 89   }
 {comment:**  meta: performance: Bb   }
 {comment:***********************************************}
 

--- a/cho/JKL/J/JoDeeMessina/ByeBye.cho
+++ b/cho/JKL/J/JoDeeMessina/ByeBye.cho
@@ -5,11 +5,13 @@
 {tempo: 134}
 {meta: nord: O24}
 {meta: countin: 8}
+{meta: backing: 89}
 {meta: performance: Bb (+3)}
 
 {comment:***********************************************}
 {comment:**  meta: nord: O24   }
 {comment:**  meta: countin: 8   }
+{comment:**  meta: backing: 89   }
 {comment:**  meta: performance: Bb (+3)   }
 {comment:***********************************************}
 

--- a/cho/JKL/J/JoeCocker/UnchainMyHeart.cho
+++ b/cho/JKL/J/JoeCocker/UnchainMyHeart.cho
@@ -5,10 +5,12 @@
 {tempo: 118}
 {meta: nord: O:24}
 {meta: countin: 0}
+{meta: backing: 86}
 
 {comment:***********************************************}
 {comment:**  meta: nord: O:24   }
 {comment:**  meta: countin: 0   }
+{comment:**  meta: backing: 86   }
 {comment:***********************************************}
 
 {comment: Intro}

--- a/cho/JKL/L/LynyrdSkynyrd/WhatsYourName.cho
+++ b/cho/JKL/L/LynyrdSkynyrd/WhatsYourName.cho
@@ -4,9 +4,11 @@
 {duration: 3:10}
 {tempo: 135}
 {meta: countin: 8 ; start with pickup}
+{meta: backing: 91}
 
 {comment:***********************************************}
 {comment:**  meta: countin: 8 ; start with pickup   }
+{comment:**  meta: backing: 91   }
 {comment:***********************************************}
 
 {comment: Intro}

--- a/cho/MNO/M/Midland/DrinkingProblem.cho
+++ b/cho/MNO/M/Midland/DrinkingProblem.cho
@@ -5,10 +5,12 @@
 {tempo: 102}
 {meta: nord: P25}
 {meta: countin: 4}
+{meta: backing: 58}
 
 {comment:***********************************************}
 {comment:**  meta: nord: P25   }
 {comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 58   }
 {comment:***********************************************}
 
 {comment: Intro}

--- a/cho/MNO/M/Mike+TheMechanics/AllINeedIsAMiracle.cho
+++ b/cho/MNO/M/Mike+TheMechanics/AllINeedIsAMiracle.cho
@@ -1,7 +1,15 @@
 {title: All I Need Is A Miracle}
 {artist: Mike and the Mechanics}
 {key: F}
+{duration: }
 {tempo: 120}
+{meta: countin: 4}
+{meta: backing: 50}
+
+{comment:***********************************************}
+{comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 50   }
+{comment:***********************************************}
 
 {comment: Intro ( drums only )}
 . | . . . . | . . . . | 

--- a/cho/MNO/N/NorahJones/DontKnowWhy.cho
+++ b/cho/MNO/N/NorahJones/DontKnowWhy.cho
@@ -5,10 +5,12 @@
 {tempo: 88}
 {meta: nord: ??}
 {meta: countin: 4}
+{meta: backing: 90}
 
 {comment:***********************************************}
 {comment:**  meta: nord: ??   }
 {comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 90   }
 {comment:***********************************************}
 
 {comment: Intro}

--- a/cho/PQR/P/PeterFrampton/ShowMeTheWay.cho
+++ b/cho/PQR/P/PeterFrampton/ShowMeTheWay.cho
@@ -4,9 +4,11 @@
 {duration: 3:45}
 {tempo: 137}
 {meta: countin: 8}
+{meta: backing: 87}
 
 {comment:***********************************************}
 {comment:**  meta: countin: 8   }
+{comment:**  meta: backing: 87   }
 {comment:***********************************************}
 
 {comment: Intro - Strumming}

--- a/cho/PQR/R/RobertPlant/CantLetGo.cho
+++ b/cho/PQR/R/RobertPlant/CantLetGo.cho
@@ -4,9 +4,13 @@
 {duration: 2:50}
 {tempo: 176}
 {meta: nord: O15}
+{meta: countin: 4}
+{meta: backing: 42}
 
 {comment:***********************************************}
 {comment:**  meta: nord: O15   }
+{comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 42   }
 {comment:***********************************************}
 
 {comment: In 2 - cut time}

--- a/cho/PQR/R/RockyBurnette/TiredOfToeinTheLine-e.cho
+++ b/cho/PQR/R/RockyBurnette/TiredOfToeinTheLine-e.cho
@@ -5,10 +5,12 @@
 {tempo: 120}
 {meta: nord: O14}
 {meta: countin: 8}
+{meta: backing: 77}
 
 {comment:***********************************************}
 {comment:**  meta: nord: O14   }
 {comment:**  meta: countin: 8   }
+{comment:**  meta: backing: 77   }
 {comment:***********************************************}
 
 {comment: Intro}

--- a/cho/PQR/R/RockyBurnette/TiredOfToeinTheLine.cho
+++ b/cho/PQR/R/RockyBurnette/TiredOfToeinTheLine.cho
@@ -5,10 +5,12 @@
 {tempo: 120}
 {meta: nord: O14}
 {meta: countin: 8}
+{meta: backing: 77}
 
 {comment:***********************************************}
 {comment:**  meta: nord: O14   }
 {comment:**  meta: countin: 8   }
+{comment:**  meta: backing: 77   }
 {comment:***********************************************}
 
 {comment: Intro}

--- a/cho/ST/S/SixpenceNoneTheRicher/KissMe.cho
+++ b/cho/ST/S/SixpenceNoneTheRicher/KissMe.cho
@@ -5,11 +5,13 @@
 {tempo: 100}
 {meta: nord: O12}
 {meta: countin: 4}
+{meta: backing: 75}
 {meta: performance: Eb}
 
 {comment:***********************************************}
 {comment:**  meta: nord: O12   }
 {comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 75   }
 {comment:**  meta: performance: Eb   }
 {comment:***********************************************}
 

--- a/cho/ST/S/SixpenceNoneTheRicher/ThereSheGoes.cho
+++ b/cho/ST/S/SixpenceNoneTheRicher/ThereSheGoes.cho
@@ -5,11 +5,13 @@
 {tempo: 123}
 {meta: nord: P24}
 {meta: countin: 4}
+{meta: backing: 76}
 {meta: performance: Bb}
 
 {comment:***********************************************}
 {comment:**  meta: nord: P24   }
 {comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 76   }
 {comment:**  meta: performance: Bb   }
 {comment:***********************************************}
 

--- a/cho/ST/S/StevieRayVaughan/HouseIsARockin-c.cho
+++ b/cho/ST/S/StevieRayVaughan/HouseIsARockin-c.cho
@@ -4,9 +4,11 @@
 {duration: 2:05}
 {tempo: 172}
 {meta: countin: 8}
+{meta: backing: 80}
 
 {comment:***********************************************}
 {comment:**  meta: countin: 8   }
+{comment:**  meta: backing: 80   }
 {comment:***********************************************}
 
 {comment: Intro}

--- a/cho/ST/S/StevieRayVaughan/HouseIsARockin.cho
+++ b/cho/ST/S/StevieRayVaughan/HouseIsARockin.cho
@@ -4,9 +4,11 @@
 {duration: 2:05}
 {tempo: 172}
 {meta: countin: 8}
+{meta: backing: 80}
 
 {comment:***********************************************}
 {comment:**  meta: countin: 8   }
+{comment:**  meta: backing: 80   }
 {comment:***********************************************}
 
 {comment: Intro}

--- a/cho/ST/T/TaylorSwift/OurSong.cho
+++ b/cho/ST/T/TaylorSwift/OurSong.cho
@@ -4,9 +4,11 @@
 {duration: 2:40}
 {tempo: 89}
 {meta: countin: 4}
+{meta: backing: 84}
 
 {comment:***********************************************}
 {comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 84   }
 {comment:***********************************************}
 
 {comment: Intro}

--- a/cho/ST/T/TravisTritt/TROUBLE.cho
+++ b/cho/ST/T/TravisTritt/TROUBLE.cho
@@ -1,8 +1,15 @@
 {title: T-R-O-U-B-L-E}
 {artist: Travis Tritt}
 {key: F}
-{tempo: 178}
 {duration: 2:45}
+{tempo: 178}
+{meta: countin: 4}
+{meta: backing: 88}
+
+{comment:***********************************************}
+{comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 88   }
+{comment:***********************************************}
 
 {start_of_verse: Verse}
 Well I play an [Bb]old guitar from nine till half past o-[F]ne

--- a/cho/UV-Z/W/Weezer/IslandInTheSun.cho
+++ b/cho/UV-Z/W/Weezer/IslandInTheSun.cho
@@ -5,10 +5,12 @@
 {tempo: 115}
 {meta: nord: P54}
 {meta: countin: 4}
+{meta: backing: 79}
 
 {comment:***********************************************}
 {comment:**  meta: nord: P54   }
 {comment:**  meta: countin: 4   }
+{comment:**  meta: backing: 79   }
 {comment:***********************************************}
 
 {comment: Intro}

--- a/song-catalog.csv
+++ b/song-catalog.csv
@@ -2,7 +2,8 @@ TITLE,ARTIST,KEY,DURATION,TEMPO,COUNTIN,BACKING,NORD,ROLAND,VE,PERFORMANCE KEY,T
 Dancing Queen (Altered),Abba,E,,,,,,,,,,,,./cho/ABC/A/Abba/DancingQueenAltered-e.cho
 Dancing Queen (Altered),Abba,A,,,,,,,,,,,,./cho/ABC/A/Abba/DancingQueenAltered.cho
 Does Your Mother Know,Abba,G,3:10,120,8,62,M22,,,,,,,./cho/ABC/A/Abba/DoesYourMotherKnow.cho
-How Long,Ace,C,3:01,121,4,,,,,,,,,./cho/ABC/A/Ace/HowLong.cho
+How Long,Ace,A,3:00,121,4,48,,,,,,,,./cho/ABC/A/Ace/HowLong-a.cho
+How Long,Ace,Bb,3:00,121,4,48,,,,,,,,./cho/ABC/A/Ace/HowLong.cho
 Take On Me,Aha,A,3:00,100,,,,,,,,,,./cho/ABC/A/Aha/TakeOnMe.cho
 "Dancin', Shaggin' on the Boulevard",Alabama,A,,,,,,,,,,,,./cho/ABC/A/Alabama/DancinShagginOnTheBoulevard.cho
 Remember When,Alan Jackson,G,3:00,100,,,,,,,,,,./cho/ABC/A/AlanJackson/RememberWhen.cho
@@ -10,7 +11,7 @@ Remember When (Linda's Version),"Alan Jackson, Scott Davidson",G,3:00,100,,,,,,,
 Undercover Angel,Alan O'Day,Bb,3:30,98,,,,,,,,,,./cho/ABC/A/AlanODay/UndercoverAngel.cho
 Don't Answer Me,Alan Parsons Project,G,,,,,,,,,,,,./cho/ABC/A/AlanParsonsProject/DontAnswerMe.cho
 Eye In The Sky,Alan Parsons Project,D,,,,,,,,,,,,./cho/ABC/A/AlanParsonsProject/EyeInTheSky.cho
-It Never Rains in Southern California,Albert Hammond,G,3:20,117,4,,O23,,,,,,,./cho/ABC/A/AlbertHammond/ItNeverRains.cho
+It Never Rains in Southern California,Albert Hammond,G,3:20,117,4,71,O23,,,,,,,./cho/ABC/A/AlbertHammond/ItNeverRains.cho
 Lost In Your Own Life,Alexa Vega,C,,,,,,,,,,,,./cho/ABC/A/AlexaVega/LostInYourOwnLife.cho
 Let's Stay Together,Al Green,F,,,,,,,,,,,,./cho/ABC/A/AlGreen/LetsStayTogether.cho
 If I Ain't Got You,Alicia Keys,G,,,,,,,,,,,,./cho/ABC/A/AliciaKeys/IfIAintGotYou.cho
@@ -20,7 +21,7 @@ Year of the Cat,Al Stewart,Em,4:00,116,4,20,M22,,U6,,,,,./cho/ABC/A/AlStewart/Ye
 A Horse With No Name,America,Em,3:40,123,,,,,,,,,,./cho/ABC/A/America/AHorseWithNoName.cho
 Lonely People,America,D,2:10,155,,,M15(A3),,,,,,,./cho/ABC/A/America/LonelyPeople.cho
 Ventura Highway,America,G,3:20,130,???,,???,,,,,,,./cho/ABC/A/America/VenturaHighway.cho
-You Can Do Magic,America,Em,3:40,130,8,,,,,,,,,./cho/ABC/A/America/YouCanDoMagic.cho
+You Can Do Magic,America,Em,3:40,130,8,92,,,,,,,,./cho/ABC/A/America/YouCanDoMagic.cho
 Sweet Pea,Amos Lee,C,2:00,100,,,,,,E,,,,./cho/ABC/A/AmosLee/SweetPea.cho
 Valerie,Ami Winehouse,Eb,3:10,105,4,,P54,,,,,,,./cho/ABC/A/AmyWinehouse/Valerie.cho
 Shadows In The Moonlight,Anne Murray,A,,,,,,,,,,,,./cho/ABC/A/AnneMurray/ShadowsInTheMoonlight.cho
@@ -29,10 +30,10 @@ City of New Orleans,Arlo Guthrie,D,3:45,152,,,O24,,,,,,,./cho/ABC/A/ArloGuthrie/
 Do It Or Die,ARS,D,,,,,,,,,,,,./cho/ABC/A/ARS/DoItOrDie.cho
 So Into You,ARS,Fm,3:50,87,,,,,,,,,,./cho/ABC/A/ARS/SoIntoYou.cho
 Spooky,ARS,Em,3:22,106,4,,P34,C013,,,,,,./cho/ABC/A/ARS/Spooky.cho
-Complicated,Avril Lavigne,C#m,3:40,78,4,,,,,C#m,,,,./cho/ABC/A/AvrilLavigne/Complicated-c#m.cho
-Complicated,Avril Lavigne,Em,3:40,78,,,,,,,,,,./cho/ABC/A/AvrilLavigne/Complicated-em.cho
-Complicated,Avril Lavigne,Dm,3:40,78,,,,,,,,,,./cho/ABC/A/AvrilLavigne/Complicated.cho
-Takin' Care of Business,Bachman Turner Overdrive (BTO),C,4:50,130,,,N41,,,,,,,./cho/ABC/B/BachmanTurnerOverdrive/TakinCareOfBusiness.cho
+Complicated,Avril Lavigne,C#m,3:40,78,4,94,,,,C#m,,,,./cho/ABC/A/AvrilLavigne/Complicated-c#m.cho
+Complicated,Avril Lavigne,Em,3:40,78,4,94,,,,,,,,./cho/ABC/A/AvrilLavigne/Complicated-em.cho
+Complicated,Avril Lavigne,Dm,3:40,78,4,94,,,,,,,,./cho/ABC/A/AvrilLavigne/Complicated.cho
+Takin' Care of Business,Bachman Turner Overdrive (BTO),C,4:50,130,8,25,N41,,,,,,,./cho/ABC/B/BachmanTurnerOverdrive/TakinCareOfBusiness.cho
 When I See You Smile,Bad English,G,,,,,,,,,,,,./cho/ABC/B/BadEnglish/WhenISeeYouSmile.cho
 Evangeline,The Band,A,2:50,140,,,,,,,,,,./cho/ABC/B/Band/Evangeline.cho
 Eternal Flame,The Bangles,G,3:50,80,,,,,,,,,,./cho/ABC/B/Bangles/EternalFlame.cho
@@ -125,7 +126,7 @@ Put Your Records On,Corrine Bailey Rae,A,3:00,96,4,,N24,,,,,,,./cho/ABC/C/Corrin
 Accidentally In Love,Counting Crows,G,3:00,138,4,,O11,,,,,,,./cho/ABC/C/CountingCrows/AccidentallyInLove.cho
 Just A Song Before I Go,"Crosby, Stills, Nash and Young",Dm,4:00,107,,,M14(A2),,,Dm,,,,./cho/ABC/C/CSNY/JustASongBeforeIGo.cho
 Just Like Heaven,The Cure,A,3:10,153,,,,,,,,,,./cho/ABC/C/Cure/JustLikeHeaven.cho
-( I Just ) Died In Your Arms,Cutting Crew,Bm,4:05,125,8,,,,,,,,,./cho/ABC/C/CuttingCrew/DiedInYourArms.cho
+( I Just ) Died In Your Arms,Cutting Crew,Bm,4:05,125,8,45,,,,,,,,./cho/ABC/C/CuttingCrew/DiedInYourArms.cho
 Beautiful Sunday,Daniel Boone,C,3:00,120,,,P55,,,,,,1.0,./cho/DEF/D/DanielBoone/BeautifulSunday.cho
 Hold My Hand,Hootie (Darius Rucker) and the Blowfish,B,3:35,101,,,,,,,,,,./cho/DEF/D/DariusRucker/HoldMyHand.cho
 Wagon Wheel,Darius Rucker,G,3:50,148,4,,O55,,,,,,1.0,./cho/DEF/D/DariusRucker/WagonWheel.cho
@@ -139,7 +140,7 @@ Wide Open Spaces,Dixie Chicks,D,3:00,90,,,N31,,,,,,,./cho/DEF/D/DixieChicks/Wide
 Vincent,Don McLean,G,,,,,,,,,,,,./cho/DEF/D/DonMcLean/Vincent.cho
 Hot Stuff,Donna Summer,Gm,,,,,,,,,,,,./cho/DEF/D/DonnaSummer/HotStuff.cho
 Long Train Runnin’,Doobie Brothers,Gm,,,,,,,,,,,,./cho/DEF/D/DoobieBros/LongTrainRunning-MVP.cho
-Long Train Runnin',Doobie Brothers,Gm,3:20,117,,,,,,,,,,./cho/DEF/D/DoobieBros/LongTrainRunning.cho
+Long Train Runnin',Doobie Brothers,Gm,3:20,117,4,82,,,,,,,,./cho/DEF/D/DoobieBros/LongTrainRunning.cho
 Takin' It To The Streets,Doobie Brothers,B,,,,,,,,,,,,./cho/DEF/D/DoobieBros/TakinItToTheStreets-b.cho
 Takin' It To The Streets,Doobie Brothers,F,,,,,,,,,,,,./cho/DEF/D/DoobieBros/TakinItToTheStreets.cho
 Sharing The Night Together,Dr. Hook,C,,,,,,,,,,,,./cho/DEF/D/DrHook/SharingTheNightTogether.cho
@@ -200,7 +201,7 @@ Breakup Song,Greg Kihn,Am,2:49,136,4,,P41,,,F#m,,,,./cho/GHI/G/GregKihn/BreakupS
 Undun,Guess Who,Em,3:30,100,,,,,,,,,,./cho/GHI/G/GuessWho/Undun.cho
 Hearts Are Gonna Roll,Hal Ketchum,D,3:15,100,8,12,P21,,P13,,,,,./cho/GHI/H/HalKetchum/HeartsAreGonnaRoll.cho
 Past The Point Of Rescue,Hal Ketchum,Em,2:43,96,8,15,O:24,,,Em,,,,./cho/GHI/H/HalKetchum/PastThePointOfRescue.cho
-Small Town Saturday Night,Hal Ketchum,G,2:30,100,8,,,,,G,,,,./cho/GHI/H/HalKetchum/SmallTownSaturdayNight.cho
+Small Town Saturday Night,Hal Ketchum,G,2:30,100,8,49,,,,G,,,,./cho/GHI/H/HalKetchum/SmallTownSaturdayNight.cho
 Softer Than a Whisper,Hal Ketchum,C,3:05,95,,,,,,,,,,./cho/GHI/H/HalKetchum/SofterThanAWhisper.cho
 Everything Your Heart Desires,Hall & Oates,A,,108,,,,,,,,,,./cho/GHI/H/HallAndOates/EverythingYourHeartDesires.cho
 I Can't Go For That,Hall & Oates,Eb,,,,,,,,,,,,./cho/GHI/H/HallAndOates/ICantGoForThat.cho
@@ -219,14 +220,14 @@ Stay,Jackson Browne,G,3:00,106,,,P25,,,,,,,./cho/JKL/J/JacksonBrowne/Stay.cho
 Get Up,James Brown,Eb,3:15,140,,,,,,,,,,./cho/JKL/J/JamesBrown/GetUp.cho
 I'm Yours,Jason Mraz,B,3:45,75,,,,,,,,,,./cho/JKL/J/JasonMraz/ImYours.cho
 Who Will Save My Soul,Jewel,Am,,126,,,,,,,,,,./cho/JKL/J/Jewel/WhoWillSaveMySoul.cho
-Bad Bad Leroy Brown,Jim Croce,G,2:35,148,8,,O55,,,,,,,./cho/JKL/J/JimCroce/BadBadLeroyBrown.cho
+Bad Bad Leroy Brown,Jim Croce,G,2:35,148,8,85,O55,,,,,,,./cho/JKL/J/JimCroce/BadBadLeroyBrown.cho
 You Don't Mess Around With Jim,Jim Croce,F,,164,,,,,,,,,,./cho/JKL/J/JimCroce/YouDontMessAroundWithJim.cho
 Call Me The Breeze,J.J. Cale,F#,3:10,180,,,,,,,,,,./cho/JKL/J/JJCale/CallMeTheBreeze.cho
 Sensitive Kind,JJ Cale,Dm,5:00,101,,,N11,,,,,,,./cho/JKL/J/JJCale/SensitiveKind.cho
-Bye Bye,Jo Dee Messina,Bb,3:12,134,8,,O24,,,Bb,,,,./cho/JKL/J/JoDeeMessina/ByeBye-bb.cho
-Bye Bye,Jo Dee Messina,G,3:12,134,8,,O24,,,Bb (+3),,,,./cho/JKL/J/JoDeeMessina/ByeBye.cho
-Unchain My Heart,Joe Cocker,Am,5:07,118,0,,O:24,,,,,,,./cho/JKL/J/JoeCocker/UnchainMyHeart.cho
-Unchain My Heart (Extended),Joe Cocker,Am,5:07,118,0,18,O:24,,,,,,,./cho/JKL/J/JoeCocker/UnchainMyHeartExtended.cho
+Bye Bye,Jo Dee Messina,Bb,3:12,134,8,89,O24,,,Bb,,,,./cho/JKL/J/JoDeeMessina/ByeBye-bb.cho
+Bye Bye,Jo Dee Messina,G,3:12,134,8,89,O24,,,Bb (+3),,,,./cho/JKL/J/JoDeeMessina/ByeBye.cho
+Unchain My Heart,Joe Cocker,Am,5:07,118,0,86,O:24,,,,,,,./cho/JKL/J/JoeCocker/UnchainMyHeart.cho
+Unchain My Heart (Extended),Joe Cocker,Am,5:07,118,0,,O:24,,,,,,,./cho/JKL/J/JoeCocker/UnchainMyHeartExtended.cho
 Memphis in the Meantime,John Hiatt,E,,,,,,,,,,,,./cho/JKL/J/JohnHiatt/MemphisInTheMeantime.cho
 Beautiful Boy,John Lennon,D,,100,,,,,,,,,,./cho/JKL/J/JohnLennon/BeautifulBoy.cho
 Oh My Love,John Lennon,A,2:45,64,,,,,,,,,,./cho/JKL/J/JohnLennon/OhMyLove.cho
@@ -237,7 +238,7 @@ I’m Gonna Find Another You,John Mayer,A,3:00,150,,,,,,,,,,./cho/JKL/J/JohnMaye
 Ain't Even Done With The Night,John Mellencamp,A,4:10,120,8,29,N12,,,,,,,./cho/JKL/J/JohnMellencamp/AintEvenDoneWithTheNight-a.cho
 Ain't Even Done With The Night,John Mellencamp,B,4:10,120,8,29,N12,,,,,,,./cho/JKL/J/JohnMellencamp/AintEvenDoneWithTheNight.cho
 Cherry Bomb,John Mellencamp,G,4:10,113,,,,,,,,,,./cho/JKL/J/JohnMellencamp/CherryBomb.cho
-Jack and Diane,John Mellencamp,A,3:40,104,4,,,,,A,,,,./cho/JKL/J/JohnMellencamp/JackandDiane.cho
+Jack and Diane,John Mellencamp,A,3:40,104,4,74,,,,A,,,,./cho/JKL/J/JohnMellencamp/JackandDiane.cho
 R.O.C.K. In The U.S.A,John Mellencamp,E,2:55,166,8,54,,,,,,,,./cho/JKL/J/JohnMellencamp/ROCKInTheUSA.cho
 Looking for Love,Johnny Lee,E,,120,,,,,,,,,,./cho/JKL/J/JohnnyLee/LookingForLove.cho
 Don't Forget (Welcome to Wrexham),Jon Hume,C,,,,,,,,,,,,./cho/JKL/J/JonHume/DontForget.cho
@@ -283,7 +284,7 @@ What A Wonderful World,Louis Armstrong,F,,108,,,,,,,,,,./cho/JKL/L/LouisArmstron
 Play It Again,Luke Bryan,C,,,,,,,,,,,,./cho/JKL/L/LukeBryan/PlayItAgain.cho
 Just Like Heaven,The Cure / Lumineers,A,,,,,,,,,,,,./cho/JKL/L/Lumineers/JustLikeHeaven.cho
 Sweet Home Alabama,Lynard Skynard,D,,,,,,,,,,,,./cho/JKL/L/LynyrdSkynyrd/SweetHomeAlabama.cho
-What's Your Name,Lynyrd Skynyrd,G,3:10,135,8 ; start with pickup,,,,,,,,,./cho/JKL/L/LynyrdSkynyrd/WhatsYourName.cho
+What's Your Name,Lynyrd Skynyrd,G,3:10,135,8 ; start with pickup,91,,,,,,,,./cho/JKL/L/LynyrdSkynyrd/WhatsYourName.cho
 I Wish You Would,Mackenzie Carpenter & Midland,D,3:10,,,,,,,,,,,./cho/MNO/M/MackenzieCarpenter/IWishYouWould.cho
 La Isla Bonita,Madonna,C#m,4:00,100,8,59,P54,,,C#m,,,,./cho/MNO/M/Madonna/LaIslaBonita.cho
 Dream A Little Dream Of Me,Mama Cass,C,,133,,,,,,,,,,./cho/MNO/M/MamaCass/DreamALittleDream-c.cho
@@ -299,13 +300,13 @@ Are You Hungry Tonight?,Michael Sadri,C,2:50,66,,,,,,,3/4,,,./cho/MNO/M/MichaelS
 Going To Montana - Original,Michael Sadri,C,,,,,,,,,,,,./cho/MNO/M/MichaelSadri/GoingToMontana-orig.cho
 Going To Montana,"Michael Sadri, Scott Davidson",Am,3:30,136,,,,,,,,,,./cho/MNO/M/MichaelSadri/GoingToMontana.cho
 Cheatin' Songs,Midland,D,3:10,110,,,,,,,,,,./cho/MNO/M/Midland/CheatinSong.cho
-Drinkin' Problem,Midland,A,3:00,102,4,,P25,,,,,,,./cho/MNO/M/Midland/DrinkingProblem.cho
+Drinkin' Problem,Midland,A,3:00,102,4,58,P25,,,,,,,./cho/MNO/M/Midland/DrinkingProblem.cho
 Fourteen Gears,Midland,D,,,,,,,,,,,,./cho/MNO/M/Midland/FourteenGears.cho
 Old Fashioned Feeling,Midland,G,,,,,,,,,,,,./cho/MNO/M/Midland/OldFashionedFeeling.cho
 Roll Away,Midland,C,,,,,,,,,,,,./cho/MNO/M/Midland/RollAway.cho
 Take Her Off Your Hands,Midland,D,,,,,,,,,,,,./cho/MNO/M/Midland/TakeHerOffYourHands.cho
 Vegas,Midland,D,3:28,133,,,,,,,,,,./cho/MNO/M/Midland/Vegas.cho
-All I Need Is A Miracle,Mike and the Mechanics,F,,120,,,,,,,,,,./cho/MNO/M/Mike+TheMechanics/AllINeedIsAMiracle.cho
+All I Need Is A Miracle,Mike and the Mechanics,F,,120,4,50,,,,,,,,./cho/MNO/M/Mike+TheMechanics/AllINeedIsAMiracle.cho
 Your Love Stays With Me,Mike Reid,E,,,,,,,,,,,,./cho/MNO/M/MikeReid/YourLoveStaysWithMe.cho
 Butterfly Fly Away,Miley Cyrus / Billy Ray Cyrus,Eb,2:35,136,,,P23,,,,,,,./cho/MNO/M/MileyCyrus/ButterflyFlyAway.cho
 Flowers,Miley Cyrus,Am,3:00,122,8,,N21,,,,,,,./cho/MNO/M/MileyCyrus/Flowers.cho
@@ -330,7 +331,7 @@ This Town,Niall Horan,G,,,,,,,,,,,,./cho/MNO/N/NiallHoran/ThisTown.cho
 Cruel To Be Kind,Nick Lowe,C,3:10,125,8,16,P11,,P26,,,,,./cho/MNO/N/NickLowe/CruelToBeKind.cho
 Dancin' Shoes,Nigel Olsson,Bm,,101,,,,,,,,,,./cho/MNO/N/NigelOlsson/DancinShoes.cho
 Don't Speak,No Doubt(Gwen Stephani),Cm,3:45,76,4,,N45,,,,,,,./cho/MNO/N/NoDoubt/DontSpeak.cho
-Don't Know Why,Norah Jones,Bb,3:06,88,4,,??,,,,,,,./cho/MNO/N/NorahJones/DontKnowWhy.cho
+Don't Know Why,Norah Jones,Bb,3:06,88,4,90,??,,,,,,,./cho/MNO/N/NorahJones/DontKnowWhy.cho
 Use Ta Be My Girl,O'Jays,F,,,,,,,,,,,,./cho/MNO/O/O_Jays/UseTaBeMyGirl.cho
 Firewater,Old Crow Medicine Show,G],3:00,,,,,,,,,,,./cho/MNO/O/OldCrowMedicineShow/Firewater.cho
 All I Want,Olivia Rodrigo,G,,,,,,,,,,,,./cho/MNO/O/OliviaRodrigo/AllIWant.cho
@@ -342,7 +343,7 @@ Kodachrome,Paul Simon,D,,136,,,,,,,,,,./cho/PQR/P/PaulSimon/Kodachrome.cho
 You Have The Right To Remain Silent,Perfect Stranger,G,,,,,,,,,,,,./cho/PQR/P/PerfectStranger/YouHaveTheRightToRemainSilent.cho
 Baby I Love Your Way,Peter Frampton,G,3:40,78,,,,,,,,,,./cho/PQR/P/PeterFrampton/BabyILoveYourWay.cho
 I'm In You,Peter Frampton,C,4:00,99,,,,,,C,,,,./cho/PQR/P/PeterFrampton/ImInYou.cho
-Show Me The Way,Peter Frampton,D,3:45,137,8,,,,,,,,,./cho/PQR/P/PeterFrampton/ShowMeTheWay.cho
+Show Me The Way,Peter Frampton,D,3:45,137,8,87,,,,,,,,./cho/PQR/P/PeterFrampton/ShowMeTheWay.cho
 Let My Love Open The Door,Pete Townsend,A,2:30,165,8,22,M51,,U35,A,,,,./cho/PQR/P/PeteTownsend/LetMyLoveOpenTheDoor.cho
 Do You Remember ?,Phil Collins,F,,,,,,,,,,,,./cho/PQR/P/PhilCollins/DoYouRemember.cho
 I Had Some Help,Post Malone ( w/ Morgan Wallen),C,,,,,,,,,,,,./cho/PQR/P/PostMalone/IHadSomeHelp.cho
@@ -370,9 +371,9 @@ Steal Away,Robbie Dupree,F,,,,,,,,,,,,./cho/PQR/R/RobbieDupree/StealAway.cho
 Killing Me Softly With His Song,Roberta Flack,A,,122,,,,,,,,,,./cho/PQR/R/RobertaFlack/KillingMeSoftly-a.cho
 Bad Case Of Lovin' You,Robert Palmer,E,2:50,146,8,34,,,,,,,,./cho/PQR/R/RobertPalmer/BadCaseOfLovinYou.cho
 Every Kinda People,Robert Palmer,F,,,,,,,,,,,,./cho/PQR/R/RobertPalmer/EveryKindaPeople.cho
-Can't Let Go,Robert Plant & Alison Krauss,E,2:50,176,,,O15,,,,,,,./cho/PQR/R/RobertPlant/CantLetGo.cho
-Tired Of Toein' The Line,Rocky Burnette,E,3:30,120,8,,O14,,,,,,,./cho/PQR/R/RockyBurnette/TiredOfToeinTheLine-e.cho
-Tired Of Toein' The Line,Rocky Burnette,G,3:30,120,8,,O14,,,,,,,./cho/PQR/R/RockyBurnette/TiredOfToeinTheLine.cho
+Can't Let Go,Robert Plant & Alison Krauss,E,2:50,176,4,42,O15,,,,,,,./cho/PQR/R/RobertPlant/CantLetGo.cho
+Tired Of Toein' The Line,Rocky Burnette,E,3:30,120,8,77,O14,,,,,,,./cho/PQR/R/RockyBurnette/TiredOfToeinTheLine-e.cho
+Tired Of Toein' The Line,Rocky Burnette,G,3:30,120,8,77,O14,,,,,,,./cho/PQR/R/RockyBurnette/TiredOfToeinTheLine.cho
 Honky Tonk Women,The Rolling Stones,G,2:50,121,4,,N51,,,,4/4,,,./cho/PQR/R/RollingStones/HonkyTonkWomen.cho
 Miss You,Rolling Stones,Am,,,,,,,,,,,,./cho/PQR/R/RollingStones/MissYou.cho
 Under My Thumb,Rolling Stones,A,3:40,127,8 (with pickup)),43,P51,,,,,,,./cho/PQR/R/RollingStones/UnderMyThumb.cho
@@ -400,8 +401,8 @@ We May Never Pass This Way Again,Seals & Crofts,E,3:50,45,4,18,M14,,,,,,,./cho/S
 She's Not There / Venus,Zombies / Shocking Blue,A,4:00,,,,O21,,,,,,,./cho/ST/S/ShockingBlue/ShesNotThere-Venus.cho
 Venus,Shocking Blue,A,,,,,,,,,,,,./cho/ST/S/ShockingBlue/Venus.cho
 Leave the Door Open,Silk Sonic,F,,,,,,,,,,,,./cho/ST/S/SilkSonic/LeaveTheDoorOpen.cho
-Kiss Me,Sixpence None The Richer,C,2:50,100,4,,O12,,,Eb,,,,./cho/ST/S/SixpenceNoneTheRicher/KissMe.cho
-There She Goes,Sixpence None The Richer,G,2:42,123,4,,P24,,,Bb,,,,./cho/ST/S/SixpenceNoneTheRicher/ThereSheGoes.cho
+Kiss Me,Sixpence None The Richer,C,2:50,100,4,75,O12,,,Eb,,,,./cho/ST/S/SixpenceNoneTheRicher/KissMe.cho
+There She Goes,Sixpence None The Richer,G,2:42,123,4,76,P24,,,Bb,,,,./cho/ST/S/SixpenceNoneTheRicher/ThereSheGoes.cho
 I'll Be Around,Spinners,E,,120,,,,,,,,,,./cho/ST/S/Spinners/IllBeAround.cho
 Sweet City Woman,Stampeders,G,,,,,,,,,,,,./cho/ST/S/Stampeders/SweetCityWoman.cho
 Moonlight Feels Right,Starbuck,C,,,,,,,,,,,,./cho/ST/S/Starbuck/MoonlightFeelsRight.cho
@@ -409,8 +410,8 @@ Good Corn Liquor,Steeldrivers,E,,,,,,,,,,,,./cho/ST/S/Steeldrivers/GoodCornLiquo
 Born To Be Wild,"Steppenwolf, Adam Lambert",E,,,,,,,,,,,,./cho/ST/S/Steppenwolf/BornToBeWild.cho
 Take The Money And Run (BASS),Steve Miller Band,G,2:52,,,,,,,,,,,./cho/ST/S/SteveMillerBand/TakeTheMoneyAndRun-Bass.cho
 Take The Money And Run,Steve Miller Band,G,2:52,,,,,,,,,,,./cho/ST/S/SteveMillerBand/TakeTheMoneyAndRun.cho
-House is a Rockin',Stevie Ray Vaughan,C,2:05,172,8,,,,,,,,,./cho/ST/S/StevieRayVaughan/HouseIsARockin-c.cho
-House is a Rockin',Stevie Ray Vaughan,B,2:05,172,8,,,,,,,,,./cho/ST/S/StevieRayVaughan/HouseIsARockin.cho
+House is a Rockin',Stevie Ray Vaughan,C,2:05,172,8,80,,,,,,,,./cho/ST/S/StevieRayVaughan/HouseIsARockin-c.cho
+House is a Rockin',Stevie Ray Vaughan,B,2:05,172,8,80,,,,,,,,./cho/ST/S/StevieRayVaughan/HouseIsARockin.cho
 Don't You Worry 'Bout A Thing,Stevie Wonder,Ebm,,,,,,,,,,,,./cho/ST/S/StevieWonder/DontYouWorryBoutAThing.cho
 Lately,Stevie Wonder,C,3:30,,,,,,,,,,,./cho/ST/S/StevieWonder/Lately.cho
 White Sands,Still Corners,Dm,,,,,,,,,,,,./cho/ST/S/StillCorners/WhiteSands.cho
@@ -420,7 +421,7 @@ Little by Little,Susan Tedeschi,E,,,,,,,,,,,,./cho/ST/S/SusanTedeschi/LittleByLi
 Stumblin' In,Suzy Quatro,G,,,,,,,,,,,,./cho/ST/S/SuziQuatro/StumblinIn.cho
 Nobody,Sylvia,C,3:10,,8,63,P00,,,,,,,./cho/ST/S/Sylvia/Nobody.cho
 Get It On,T.Rex,E,4:00,125,,,,,,,,,,./cho/ST/T/T.Rex/GetItOn.cho
-Our Song,Taylor Swift,D,2:40,89,4,,,,,,,,,./cho/ST/T/TaylorSwift/OurSong.cho
+Our Song,Taylor Swift,D,2:40,89,4,84,,,,,,,,./cho/ST/T/TaylorSwift/OurSong.cho
 Style,Taylor Swift,G,,,,,,,,,,,,./cho/ST/T/TaylorSwift/Style.cho
 You Belong With Me,Taylor Swift,G,,,,,,,,,,,,./cho/ST/T/TaylorSwift/YouBelongWithMe.cho
 Seasons in the Sun,Terry Jacks,F,3:30,100,,,,,,,,,,./cho/ST/T/TerryJacks/SeasonsInTheSun.cho
@@ -446,19 +447,19 @@ Here Comes My Girl,Tom Petty and the Heartbreakers,E,4:00,104,4,28,,,,,,,,./cho/
 Into The Great Wide Open,Tom Petty,Em,3:20,82,,,,,,,,,,./cho/ST/T/TomPetty/IntoTheGreatWideOpen.cho
 Learning to Fly,Tom Petty,C,3:40,116,8,,???,,,C,,,,./cho/ST/T/TomPetty/LearningToFly.cho
 Mary Jane's Last Dance,Tom Petty & The Heartbreakers,Am,3:20,85,4,27,,,,,,,,./cho/ST/T/TomPetty/MaryJanesLastDance.cho
-Runnin' Down A Dream,Tom Petty,E,3:45,170,8,,N51,,,E,,,,./cho/ST/T/TomPetty/RunningDownADream.cho
+Runnin' Down A Dream,Tom Petty,E,3:45,170,8,68,N51,,,E,,,,./cho/ST/T/TomPetty/RunningDownADream.cho
 You Don't Know How It Feels,Tom Petty,E,3:45,74,,,P31,,,,,,,./cho/ST/T/TomPetty/YouDontKnowHowItFeels.cho
 You Wreck Me,Tom Petty,D,3:05,164,8,35,,,,,,,,./cho/ST/T/TomPetty/YouWreckMe.cho
 You Wanted More,Tonic,E,,114,,,,,,,,,,./cho/ST/T/Tonic/YouWantedMore.cho
 Hey Soul Sister,Train,B,,,,,,,,,,,,./cho/ST/T/Train/HeySoulSister.cho
 Handle With Care,Traveling Wilburys,G,3:18,122,4,38,M22,,P12,,,,,./cho/ST/T/TravelingWilburys/HandleWithCare.cho
-T-R-O-U-B-L-E,Travis Tritt,F,2:45,178,,,,,,,,,,./cho/ST/T/TravisTritt/TROUBLE.cho
+T-R-O-U-B-L-E,Travis Tritt,F,2:45,178,4,88,,,,,,,,./cho/ST/T/TravisTritt/TROUBLE.cho
 Stuck In A Moment / I Still Haven't Found,U2,E / C,,TBD,,,N51,,,N51,,,,./cho/UV-Z/U2/StuckInAMoment-IStillHaventFound.cho
 Jump,Van Halen,C,3:55,130,,,,,,,,,,./cho/UV-Z/V/VanHalen/Jump.cho
 Brown Eyed Girl,Van Morrison,G,3:01,149,8,31,P55,,,,,,,./cho/UV-Z/V/VanMorrison/BrownEyedGirl.cho
 Blinding Lights,The Weeknd,Fm,3:20,171,,,,,,,,,,./cho/UV-Z/W/Weeknd/BlindingLights.cho
 Save Your Tears,The Weeknd,C,,,,,,,,,,,,./cho/UV-Z/W/Weeknd/SaveYourTears.cho
-Island In The Sun,Weezer,Em,3:00,115,4,,P54,,,,,,,./cho/UV-Z/W/Weezer/IslandInTheSun.cho
+Island In The Sun,Weezer,Em,3:00,115,4,79,P54,,,,,,,./cho/UV-Z/W/Weezer/IslandInTheSun.cho
 Crazy,Willie Nelson,Eb,2:30,,,,,,,,,,,./cho/UV-Z/W/WillieNelson/Crazy.cho
 Blue Christmas,Elvis Presley,E,1:50,95,,,,,,,,,,./cho/UV-Z/Xmas/BlueChristmas.cho
 Have Yourself A Merry Little Christmas,Bing Crosby,C,2:50,80,,,,,,,,,,./cho/UV-Z/Xmas/HaveYourselfAMerryLittleChristmas.cho

--- a/updateSongsListing.txt
+++ b/updateSongsListing.txt
@@ -1,2 +1,1 @@
-./cho/ABC/C/CuttingCrew/DiedInYourArms.cho
-./cho/ABC/A/Ace/HowLong.cho
+./cho/MNO/M/Midland/DrinkingProblem.cho


### PR DESCRIPTION
Scott,

I wanted to get the catalog file to match the latest RC-500 memory slot configuration so I went through each BT slot number on the RC-500 and checked if the song-catalog.csv file matched. There were some songs that needed updating so edited those catalog entries (source of truth) and then I ran update-songs to push the update to the respective cho files.

I checked each song file and everything looked good except for Drinking Problem. It did display the "countin" but not the "backing" value for some reason (it is 58 on the RC-500).

Anyway, everything else looks good.

Jeff
