### PR TITLE
Fixed Countin error in Hey California

### DIFF
--- a/cho/JKL/J/JonPardi/HeyCalifornia.cho
+++ b/cho/JKL/J/JonPardi/HeyCalifornia.cho
@@ -4,14 +4,14 @@
 {duration: 3:40}
 {tempo: 130}
 {meta: nord: P55}
-{meta: countin: 4}
+{meta: countin: 8}
 {meta: backing: RC}
 {meta: rc-slot: 73}
 {meta: label: Hey   Cali}
 
 {comment:***********************************************}
 {comment:**  meta: nord: P55   }
-{comment:**  meta: countin: 4   }
+{comment:**  meta: countin: 8   }
 {comment:**  meta: backing: RC   }
 {comment:**  meta: rc-slot: 73   }
 {comment:**  meta: label: Hey   Cali   }

--- a/song-catalog.csv
+++ b/song-catalog.csv
@@ -254,7 +254,7 @@ R.O.C.K. In The U.S.A,John Mellencamp,E,2:55,166,8,RC,,,,,,,JKL:J:JohnMellencamp
 Looking for Love,Johnny Lee,E,,120,,,,,,,,,JKL:J:JohnnyLee:LookingForLove,
 Don't Forget (Welcome to Wrexham),Jon Hume,C,,,,,,,,,,,JKL:J:JonHume:DontForget,
 Dirt On My Boots,Jon Pardi,C#m,3:10,90,4,,P55,,,,,,JKL:J:JonPardi:DirtOnMyBoot,
-Hey California,Jon Pardi,Em,3:40,130,4,RC,P55,,,,,,JKL:J:JonPardi:HeyCalifornia,Hey   Cali
+Hey California,Jon Pardi,Em,3:40,130,8,RC,P55,,,,,,JKL:J:JonPardi:HeyCalifornia,Hey   Cali
 Tuscon Too Late,Jordan Davis,G,,,,,,,,,,,JKL:J:JordanDavis:TusconTooLate,
 Jacksonville,Josh Turner,C,,119,,,,,,,,,JKL:J:JoshTurner:Jacksonville,
 Jacksonville,Josh Turner,D,,119,,,,,,,,,JKL:J:JoshTurner:Jacksonville-d,


### PR DESCRIPTION
Running through all FF songs for RC-500 slot values and found a countin error for Hey California. RC-500 slot value was fine but the countin should be 8 and it was 4. Just edited song-catalog.csv for that countin and did update-song and that worked fine.
