### PR TITLE
Fixed comments in AgainstTheWind-f.cho & did minor edit on ThingThatYouDo

### DIFF
--- a/cho/ABC/B/BobSeger/AgainstTheWind-f.cho
+++ b/cho/ABC/B/BobSeger/AgainstTheWind-f.cho
@@ -42,7 +42,8 @@ how she [Dm]swore that it [Bb]never would [F]end.
 I [Dm]remember how she [C]held me,  [Bb]oh so tight.
 [Bb]Wish I didn’t know now what I [C]didn’t know then.
 
-{comment: double first and last Against the wind}
+!(Double first and last "Against the Wind")
+
 [F]Against the [Am]wind,[Bb] we were running against the [F]wind.
 We were [Bb]young and [Am]strong, we were [Gm]running a[Bb]gainst the [F]wind.
 {end_of_chorus}
@@ -71,7 +72,8 @@ breaking [Dm]all of the [Bb]rules that would [F]bend.
 I be[Dm]gin to [C]find myself just [Bb]searching,
 searching for shelter a[C]gain and again.
 
-{comment: double first and last Against the wind}
+!(Double first and last "Against the Wind")
+
 [F]Against the [Am]wind,[Bb]  a little something against the [F]wind.
 I [Bb]found my[Am]self seeking [Gm]shelter a[Bb]gainst the [F]wind.
 {end_of_chorus}
@@ -93,7 +95,8 @@ I’ve got [Dm]so much [Bb]more to think a[F]bout.
 what to leave in, [C]what to leave out.
 
 {start_of_chorus}
-{comment: double first and last Against the wind}
+!(Double first and last "Against the Wind")
+
 A[F]gainst the [Am]wind,[Bb]
 I’m still running against the [F]wind.
 I’m [Bb]older [Am]now but still [Gm]running a[Bb]gainst the [F]wind.
@@ -103,7 +106,8 @@ I’m [Bb]older [Am]now but still [Gm]running a[Bb]gainst the [F]wind.
 Well, [Bb]I’m older [Am]now but still [C7]running...
 Against the [Bb]wind
 
-{comment: Against the wind harmonies: C -> Bb, Bb -> A}
+!(Against the wind harmonies: C -> Bb, Bb -> A)
+
 Against the [F]wind
 Against the [Bb]wind (still running)
 Against the [F]wind (I m still running against the wind)

--- a/cho/VWX/W/Wonders/ThatThingYouDo-a.cho
+++ b/cho/VWX/W/Wonders/ThatThingYouDo-a.cho
@@ -52,7 +52,7 @@ But it's [A]just so [A7/C#]hard to [D]do_[Dm]
 [D]I don't ask a lot, girl (I don't ask a lot, girl)
 But I [F#m]know one thing's for sure (know one thing's for sure)
 It's the [B]love I haven't got, girl
-And I j[E]ust can't take it [F]any-[E]more (Wow!)
+And I j[E]ust can't take it [F]anymore  [E] (Wow!)
 {end_of_part}
 
 {start_of_part: Guitar Solo}

--- a/cho/VWX/W/Wonders/ThatThingYouDo.cho
+++ b/cho/VWX/W/Wonders/ThatThingYouDo.cho
@@ -54,7 +54,7 @@ But it's [E]just so [E7/G#]hard to [A]do_[Am]
 [A]I don't ask a lot, girl (I don't ask a lot, girl)
 But I [C#m]know one thing's for sure (know one thing's for sure)
 It's the [F#]love I haven't got, girl
-And I j[B]ust can't take it [C]any-[B]more (Wow!)
+And I j[B]ust can't take it [C]anymore  [B] (Wow!)
 {end_of_part}
 
 {start_of_part: Guitar Solo}


### PR DESCRIPTION
Gemini stated that the best way to add a comment independent of location in OnSong 2026 is to simply add the line with a leading exclamation point:

!(Double first and last "Against the Wind")

The exclamation point formats the line as bold and italic and the parentheses makes it a lighter grey color to distinguish it from the dark bold Chorus and Verse labels.

I checked this method inside a Chorus block and outside any block (in OnSong 2026 on my laptop) and it works well in both locations.

Regarding ThatThingYouDo (both versions), the line at the end of the bridge was still a little off. It was written as:

And I j[B]ust can't take it [C]any-[B]more (Wow!)


What it should be is:
And I j[B]ust can't take it [C]anymore  [B] (Wow!)

The word "anymore" is all on one chord. The second B-chord starts after the singer finishes saying "anymore".
